### PR TITLE
fix: show real redis server time by TIME command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: node_js
 node_js:
   - '8'
-  - '9'
+  - '10'
+  - '11'
 install:
   - npm i npminstall && npminstall
 script:

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -5,6 +5,10 @@ exports.redis = {
   },
   app: true,
   agent: false,
+  // redis client will try to use TIME command to detect client is ready or not
+  // if your redis server not support TIME command, please set this config to false
+  // see https://redis.io/commands/time
+  supportTimeCommand: true,
 
   // Single Redis
   // client: {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -8,7 +8,6 @@ module.exports = app => {
 };
 
 let count = 0;
-
 function createClient(config, app) {
   let client;
 
@@ -19,36 +18,35 @@ function createClient(config, app) {
       assert(client.host && client.port && client.password !== undefined && client.db !== undefined,
         `[egg-redis] 'host: ${client.host}', 'port: ${client.port}', 'password: ${client.password}', 'db: ${client.db}' are required on config`);
     });
-    app.coreLogger.info('[egg-redis] cluster connecting start');
-
+    app.coreLogger.info('[egg-redis] cluster connecting');
     client = new Redis.Cluster(config.nodes, config);
-    client.on('connect', function() {
-      app.coreLogger.info('[egg-redis] cluster connect success');
-    });
-    client.on('error', function(error) {
-      app.coreLogger.error(error);
-    });
   } else {
     assert(config.host && config.port && config.password !== undefined && config.db !== undefined,
       `[egg-redis] 'host: ${config.host}', 'port: ${config.port}', 'password: ${config.password}', 'db: ${config.db}' are required on config`);
-
-    app.coreLogger.info('[egg-redis] connecting redis://:%s@%s:%s/%s',
-      config.password, config.host, config.port, config.db);
-
+    app.coreLogger.info('[egg-redis] server connecting redis://:***@%s:%s/%s',
+      config.host, config.port, config.db);
     client = new Redis(config);
-    client.on('connect', function() {
-      app.coreLogger.info('[egg-redis] connect success on redis://:%s@%s:%s/%s',
-        config.password, config.host, config.port, config.db);
-    });
-    client.on('error', function(error) {
-      app.coreLogger.error(error);
-    });
   }
 
+  client.on('connect', () => {
+    app.coreLogger.info('[egg-redis] client connect success');
+  });
+  client.on('error', err => {
+    app.coreLogger.error('[egg-redis] client error: %s', err);
+    app.coreLogger.error(err);
+  });
+
   app.beforeStart(async () => {
-    const result = await client.info();
     const index = count++;
-    app.coreLogger.info(`[egg-redis] instance[${index}] status OK, redis currentTime: ${result[0]}`);
+    if (app.config.redis.supportTimeCommand) {
+      const serverTimes = await client.time();
+      // [ '1543378095', '393297' ]
+      const dateTime = new Date(Number(String(serverTimes[0]) + String(serverTimes[1]).substring(0, 3)));
+      app.coreLogger.info(`[egg-redis] instance[${index}] status OK, redis server currentTime: ${dateTime}`);
+    } else {
+      await client.get('egg-redis-hello');
+      app.coreLogger.info(`[egg-redis] instance[${index}] status OK, client ready`);
+    }
   });
 
   return client;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "ci": {
     "type": "travis",
-    "version": "8, 9",
+    "version": "8, 10, 11",
     "license": true,
     "services": "redis-server"
   },

--- a/test/fixtures/apps/redisapp-supportTimeCommand-false/app/controller/home.js
+++ b/test/fixtures/apps/redisapp-supportTimeCommand-false/app/controller/home.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = app => {
+  return class HomeController extends app.Controller {
+    * index() {
+      const { ctx, app } = this;
+      yield app.redis.set('foo', 'bar');
+      ctx.body = yield app.redis.get('foo');
+    }
+  };
+};

--- a/test/fixtures/apps/redisapp-supportTimeCommand-false/app/router.js
+++ b/test/fixtures/apps/redisapp-supportTimeCommand-false/app/router.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(app) {
+  app.get('/', 'home.index');
+};

--- a/test/fixtures/apps/redisapp-supportTimeCommand-false/config/config.js
+++ b/test/fixtures/apps/redisapp-supportTimeCommand-false/config/config.js
@@ -8,12 +8,7 @@ exports.redis = {
     db: '0',
   },
   agent:true,
-};
-
-exports.logger = {
-  coreLogger: {
-    level: 'INFO',
-  },
+  supportTimeCommand: false,
 };
 
 exports.keys = 'keys';

--- a/test/fixtures/apps/redisapp-supportTimeCommand-false/package.json
+++ b/test/fixtures/apps/redisapp-supportTimeCommand-false/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "redisapp"
+}

--- a/test/redis.test.js
+++ b/test/redis.test.js
@@ -4,14 +4,13 @@ const mm = require('egg-mock');
 const request = require('supertest');
 
 describe('test/redis.test.js', () => {
-
   describe('single client', () => {
     let app;
-    before(function* () {
+    before(async () => {
       app = mm.app({
         baseDir: 'apps/redisapp',
       });
-      yield app.ready();
+      await app.ready();
     });
     after(() => app.close());
     afterEach(mm.restore);
@@ -22,6 +21,24 @@ describe('test/redis.test.js', () => {
         .expect(200)
         .expect('bar');
     });
+  });
 
+  describe('single client supportTimeCommand = false', () => {
+    let app;
+    before(async () => {
+      app = mm.app({
+        baseDir: 'apps/redisapp-supportTimeCommand-false',
+      });
+      await app.ready();
+    });
+    after(() => app.close());
+    afterEach(mm.restore);
+
+    it('should query', () => {
+      return request(app.callback())
+        .get('/')
+        .expect(200)
+        .expect('bar');
+    });
   });
 });


### PR DESCRIPTION
and allow user disable TIME command by supportTimeCommand = false

closes https://github.com/eggjs/egg/issues/3226

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
