### PR TITLE
feat: add skipHealthCheck configuration

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -5,6 +5,8 @@ exports.redis = {
   },
   app: true,
   agent: false,
+  // skipping health check, supportTimeCommand configuration will be ignored
+  skipHealthCheck: false,
   // redis client will try to use TIME command to detect client is ready or not
   // if your redis server not support TIME command, please set this config to false
   // see https://redis.io/commands/time

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -52,7 +52,7 @@ function createClient(config, app) {
   app.beforeStart(async () => {
     const index = count++;
     if (app.config.redis.skipHealthCheck) {
-        app.coreLogger.info(`[egg-redis] instances[${index}] start skipping health check`);
+      app.coreLogger.info(`[egg-redis] instances[${index}] start skipping health check`);
     } else if (app.config.redis.supportTimeCommand) {
       const serverTimes = await client.time();
       // [ '1543378095', '393297' ]

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -51,7 +51,9 @@ function createClient(config, app) {
 
   app.beforeStart(async () => {
     const index = count++;
-    if (app.config.redis.supportTimeCommand) {
+    if (app.config.redis.skipHealthCheck) {
+        app.coreLogger.info(`[egg-redis] instances[${index}] start skipping health check`);
+    } else if (app.config.redis.supportTimeCommand) {
       const serverTimes = await client.time();
       // [ '1543378095', '393297' ]
       const dateTime = new Date(Number(String(serverTimes[0]) + String(serverTimes[1]).substring(0, 3)));

--- a/test/fixtures/apps/redisapp-skipHealthCheck-true/app/controller/home.js
+++ b/test/fixtures/apps/redisapp-skipHealthCheck-true/app/controller/home.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = app => {
+  return class HomeController extends app.Controller {
+    * index() {
+      const { ctx, app } = this;
+      yield app.redis.set('foo', 'bar');
+      ctx.body = yield app.redis.get('foo');
+    }
+  };
+};

--- a/test/fixtures/apps/redisapp-skipHealthCheck-true/app/router.js
+++ b/test/fixtures/apps/redisapp-skipHealthCheck-true/app/router.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(app) {
+  app.get('/', 'home.index');
+};

--- a/test/fixtures/apps/redisapp-skipHealthCheck-true/config/config.js
+++ b/test/fixtures/apps/redisapp-skipHealthCheck-true/config/config.js
@@ -1,0 +1,20 @@
+'use strict';
+
+exports.redis = {
+  client: {
+    host: '127.0.0.1',
+    port: 6379,
+    password: '',
+    db: '0',
+    enableOfflineQueue: false
+  },
+  skipHealthCheck: true,
+};
+
+exports.logger = {
+  coreLogger: {
+    level: 'INFO',
+  },
+};
+
+exports.keys = 'keys';

--- a/test/fixtures/apps/redisapp-skipHealthCheck-true/package.json
+++ b/test/fixtures/apps/redisapp-skipHealthCheck-true/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "redisapp-skipHealCheck-true"
+}

--- a/test/redis.test.js
+++ b/test/redis.test.js
@@ -128,4 +128,23 @@ describe('test/redis.test.js', () => {
         .expect('bar');
     });
   });
+
+  describe('skip health check', () => {
+    let app;
+    before(async () => {
+      app = mm.app({
+        baseDir: 'apps/redisapp-skipHealthCheck-true',
+      });
+      await app.ready();
+    });
+    after(() => app.close());
+    afterEach(mm.restore);
+
+    it('should query', () => {
+      return request(app.callback())
+        .get('/')
+        .expect(200)
+        .expect('bar');
+    });
+  });
 });


### PR DESCRIPTION
- 添加 skipHealthCheck 的配置

当 client 的配置添加了 enableOfflineQueue: false，启动会无法绕过 `Stream isn't writeable and enableOfflineQueue options is false` 的错误。

跳过健康检查可以绕过这个报错。