### PR TITLE
fix: should listen redis ready event before app start

### DIFF
--- a/.autod.conf.js
+++ b/.autod.conf.js
@@ -15,8 +15,12 @@ module.exports = {
     'eslint',
     'eslint-config-egg',
     'supertest',
+    'typescript',
+  ],
+  dep: [
+    '@types/ioredis'
   ],
   exclude: [
     './test/fixtures',
   ],
-}
+};

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const awaitFirst = require('await-first');
 
 module.exports = app => {
   app.addSingleton('redis', createClient);
@@ -51,15 +52,8 @@ function createClient(config, app) {
 
   app.beforeStart(async () => {
     const index = count++;
-    if (app.config.redis.supportTimeCommand) {
-      const serverTimes = await client.time();
-      // [ '1543378095', '393297' ]
-      const dateTime = new Date(Number(String(serverTimes[0]) + String(serverTimes[1]).substring(0, 3)));
-      app.coreLogger.info(`[egg-redis] instance[${index}] status OK, redis server currentTime: ${dateTime}`);
-    } else {
-      await client.get('egg-redis-hello');
-      app.coreLogger.info(`[egg-redis] instance[${index}] status OK, client ready`);
-    }
+    await awaitFirst(client, [ 'ready', 'error' ]);
+    app.coreLogger.info(`[egg-redis] instance[${index}] status OK, client ready`);
   });
 
   return client;

--- a/package.json
+++ b/package.json
@@ -21,20 +21,21 @@
     "database"
   ],
   "dependencies": {
-    "ioredis": "^3.2.2",
-    "@types/ioredis": "^4.0.1"
+    "@types/ioredis": "^4.0.10",
+    "await-first": "^1.0.0",
+    "ioredis": "^4.9.0"
   },
   "devDependencies": {
     "@types/node": "^10.9.4",
-    "typescript": "^3.0.3",
-    "autod": "^3.0.1",
-    "egg": "^2.3.0",
-    "egg-bin": "^4.4.0",
-    "egg-ci": "^1.8.0",
-    "egg-mock": "^3.14.0",
-    "eslint": "^4.18.1",
-    "eslint-config-egg": "^7.0.0",
-    "supertest": "^3.0.0",
+    "autod": "^3.1.0",
+    "egg": "^2.21.1",
+    "egg-bin": "^4.13.0",
+    "egg-ci": "^1.11.0",
+    "egg-mock": "^3.22.2",
+    "eslint": "^5.16.0",
+    "eslint-config-egg": "^7.3.1",
+    "supertest": "^4.0.2",
+    "typescript": "^3.4.5",
     "utility": "^1.9.0"
   },
   "engines": {

--- a/test/fixtures/apps/redisapp-disable-offline-queue/app/controller/home.js
+++ b/test/fixtures/apps/redisapp-disable-offline-queue/app/controller/home.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = app => {
+  return class HomeController extends app.Controller {
+    * index() {
+      const { ctx, app } = this;
+      yield app.redis.set('foo', 'bar');
+      ctx.body = yield app.redis.get('foo');
+    }
+  };
+};

--- a/test/fixtures/apps/redisapp-disable-offline-queue/app/router.js
+++ b/test/fixtures/apps/redisapp-disable-offline-queue/app/router.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(app) {
+  app.get('/', 'home.index');
+};

--- a/test/fixtures/apps/redisapp-disable-offline-queue/config/config.js
+++ b/test/fixtures/apps/redisapp-disable-offline-queue/config/config.js
@@ -1,0 +1,14 @@
+'use strict';
+
+exports.redis = {
+  client: {
+    host: '127.0.0.1',
+    port: 6379,
+    password: '',
+    db: '0',
+    enableOfflineQueue: false,
+  },
+  agent: false,
+};
+
+exports.keys = 'keys';

--- a/test/fixtures/apps/redisapp-disable-offline-queue/package.json
+++ b/test/fixtures/apps/redisapp-disable-offline-queue/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "redisapp"
+}

--- a/test/fixtures/apps/ts-multi/tsconfig.json
+++ b/test/fixtures/apps/ts-multi/tsconfig.json
@@ -7,7 +7,8 @@
       "lib": [
         "es2017"
       ],
-      "skipLibCheck": false
+      "skipLibCheck": false,
+      "noImplicitAny": false
     },
     "include": [
       "../../../../**/*"

--- a/test/fixtures/apps/ts/tsconfig.json
+++ b/test/fixtures/apps/ts/tsconfig.json
@@ -7,7 +7,8 @@
       "lib": [
         "es2017"
       ],
-      "skipLibCheck": false
+      "skipLibCheck": false,
+      "noImplicitAny": false
     },
     "include": [
       "../../../../**/*"

--- a/test/redis.test.js
+++ b/test/redis.test.js
@@ -128,4 +128,23 @@ describe('test/redis.test.js', () => {
         .expect('bar');
     });
   });
+
+  describe('await ready event', () => {
+    let app;
+    before(async () => {
+      app = mm.app({
+        baseDir: 'apps/redisapp-disable-offline-queue',
+      });
+      await app.ready();
+    });
+    after(() => app.close());
+    afterEach(mm.restore);
+
+    it('should query', () => {
+      return request(app.callback())
+        .get('/')
+        .expect(200)
+        .expect('bar');
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

用监听 [ready](https://www.npmjs.com/package/ioredis#connection-events) 事件替代原来的执行 command 方案。
