### PR TITLE
fix: clients should  be Record<string ,ClusterOptions>

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ interface EggRedisOptions {
   app?: boolean;
   agent?: boolean;
   client?: ClusterOptions;
-  clients?: Record<string, RedisOptions>;
+  clients?: Record<string, ClusterOptions>;
 }
 
 declare module 'egg' {


### PR DESCRIPTION
在使用ts的过程中，发现配置文件这个编译时报错，发现index.d.ts文件中clients类型有问题。
