### PR TITLE
feat: remove node password and db validate on cluster mode

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -16,8 +16,7 @@ function createClient(config, app) {
     assert(config.nodes && config.nodes.length !== 0, '[egg-redis] cluster nodes configuration is required when use cluster redis');
 
     config.nodes.forEach(client => {
-      assert(client.host && client.port && client.password !== undefined && client.db !== undefined,
-        `[egg-redis] 'host: ${client.host}', 'port: ${client.port}', 'password: ${client.password}', 'db: ${client.db}' are required on config`);
+      assert(client.host && client.port, `[egg-redis] 'host: ${client.host}', 'port: ${client.port}' are required on config`);
     });
     app.coreLogger.info('[egg-redis] cluster connecting');
     client = new Redis.Cluster(config.nodes, config);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified Redis cluster configuration by removing the necessity for `password` and `db` parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->